### PR TITLE
Use mmap() on Unix-like OSes to allocate memory

### DIFF
--- a/TinyVM/CMakeLists.txt
+++ b/TinyVM/CMakeLists.txt
@@ -5,35 +5,26 @@ set(TVM_VERSION_MAJOR 0)
 set(TVM_VERSION_MINOR 0)
 set(TVM_VERSION_REV   5)
 
-# Windows-specific options
-if(WIN32)
-	option(ENABLE_WIN32_FILEMAPPING_MMAP "Enable FileMapping mmap optimisation" ON)
-endif()
-
-if(UNIX)
-	option(ENABLE_POSIX_FILEMAPPING_MMAP "Enable FileMapping mmap optimisations" ON)
-endif()
-
 set(TVM_CONFIG_TEMPLATE_PATH "${PROJECT_SOURCE_DIR}/config.hpp.in")
 set(TVM_CONFIG_HEADER_PATH "${PROJECT_BINARY_DIR}/config.hpp")
 configure_file(${TVM_CONFIG_TEMPLATE_PATH} ${TVM_CONFIG_HEADER_PATH})
 
 set(SRC_LIST
-	main.cpp
-	vm.cpp
-	instruction.cpp
-	instruction_implementation.cpp
-	instruction_support.cpp)
+    main.cpp
+    vm.cpp
+    instruction.cpp
+    instruction_implementation.cpp
+    instruction_support.cpp)
 
 set(HDR_LIST
-	${TVM_CONFIG_TEMPLATE_PATH}
-	${TVM_CONFIG_HEADER_PATH}
-	util.hpp
-	vm.hpp
-	instruction.hpp
-	instruction_implementation.hpp
-	instruction_support.hpp
-	vmtypes.hpp)
+    ${TVM_CONFIG_TEMPLATE_PATH}
+    ${TVM_CONFIG_HEADER_PATH}
+    util.hpp
+    vm.hpp
+    instruction.hpp
+    instruction_implementation.hpp
+    instruction_support.hpp
+    vmtypes.hpp)
 
 include_directories("${PROJECT_BINARY_DIR}")
 add_executable(${PROJECT_NAME} ${SRC_LIST} ${HDR_LIST})

--- a/TinyVM/CMakeLists.txt
+++ b/TinyVM/CMakeLists.txt
@@ -20,11 +20,18 @@ set(HDR_LIST
     ${TVM_CONFIG_TEMPLATE_PATH}
     ${TVM_CONFIG_HEADER_PATH}
     util.hpp
+    platform.hpp
     vm.hpp
     instruction.hpp
     instruction_implementation.hpp
     instruction_support.hpp
     vmtypes.hpp)
+
+if (UNIX)
+    set(SRC_LIST "${SRC_LIST}" platform_posix.cpp)
+else()
+    set(SRC_LIST "${SRC_LIST}" platform_generic.cpp)
+endif()
 
 include_directories("${PROJECT_BINARY_DIR}")
 add_executable(${PROJECT_NAME} ${SRC_LIST} ${HDR_LIST})

--- a/TinyVM/platform.hpp
+++ b/TinyVM/platform.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "vmtypes.hpp"
+
+// Map a memory region of nwords vmwords and return a pointer to it
+// Will return nullptr if the allocation fails
+vmword *plat_map_memory(size_t nwords);
+
+// Unmap a memory region mapped with plat_map_memory
+void plat_unmap_memory(vmword *mem, size_t nwords);

--- a/TinyVM/platform_posix.cpp
+++ b/TinyVM/platform_posix.cpp
@@ -1,0 +1,16 @@
+#include "platform.hpp"
+
+#include <sys/mman.h>
+
+vmword *plat_map_memory(size_t nwords)
+{
+    void *mem_ptr = mmap(nullptr, nwords * sizeof(vmword), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (mem_ptr == MAP_FAILED)
+        return nullptr;
+    return static_cast<vmword*>(mem_ptr);
+}
+
+void plat_unmap_memory(vmword *mem, size_t nwords)
+{
+    int res = munmap(mem, nwords * sizeof(vmword));
+}

--- a/TinyVM/vm.cpp
+++ b/TinyVM/vm.cpp
@@ -5,23 +5,27 @@
 
 #include <iostream>
 
+#include "platform.hpp"
+
 VMContext* vm_create()
 {
 	VMContext *ctx = new VMContext;
+    ctx->memory = plat_map_memory(VM_MEMORY_SIZE);
     prepare_instruction_table(ctx->instr_table);
-	vm_reset(ctx);
+    vm_reset(ctx);
 	return ctx;
 }
 
 void vm_destroy(VMContext *ctx)
 {
+    plat_unmap_memory(ctx->memory, VM_MEMORY_SIZE);
 	delete ctx;
 }
 
 void vm_reset(VMContext *ctx)
 {
 	ctx->running = false;
-	memset(ctx->memory, 0, sizeof(ctx->memory));
+    memset(ctx->memory, 0, VM_MEMORY_SIZE * sizeof(vmword));
 	memset(ctx->registers, 0, sizeof(ctx->registers));
 }
 
@@ -52,7 +56,7 @@ void vm_error(VMContext *ctx, const char *message)
 
 Instruction vm_fetch_decode(VMContext *ctx)
 {
-	auto data_address = reinterpret_cast<InstructionData*>(ctx->memory + ctx->registers[IP]);
+    auto data_address = reinterpret_cast<InstructionData*>(ctx->memory + ctx->registers[IP]);
 	auto instr = vmi_decode(data_address);
 	ctx->registers[IP] += 4;
 	return instr;

--- a/TinyVM/vm.hpp
+++ b/TinyVM/vm.hpp
@@ -34,7 +34,7 @@ enum Registers
     VM_REGISTER_COUNT,
 };
 
-const size_t VM_MEMORY_SIZE = 16384;
+const size_t VM_MEMORY_SIZE = 0x10000;
 
 struct VMContext
 {
@@ -42,7 +42,7 @@ struct VMContext
     instr_func instr_table[INSTRUCTION_COUNT];
 
     vmword registers[VM_REGISTER_COUNT];
-    vmword memory[VM_MEMORY_SIZE];
+    vmword *memory;
 };
 
 // Create a new vm context and reset it


### PR DESCRIPTION
This also significantly increases the available memory for VMs
